### PR TITLE
REFACTOR: Fixed some compilation warnings (#1604)

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionUtil.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionUtil.scala
@@ -55,7 +55,7 @@ object ExecutionUtil {
    * final aggregation of the Monoids computed for each duration.
    */
   def runDateRangeWithParallelismSum[T](duration: Duration, parallelism: Int = 1)(fn: DateRange => Execution[T])(implicit dr: DateRange, semigroup: Semigroup[T]): Execution[T] = {
-    require(dr.each(duration).nonEmpty, s"Date Range can not be empty")
+    require(dr.each(duration).nonEmpty, "Date Range can not be empty")
 
     runDateRangeWithParallelism(duration, parallelism)(fn)(dr)
       .map(_.reduceLeft[T]{ case (l, r) => Semigroup.plus(l, r) })

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -467,10 +467,6 @@ package com.twitter.scalding {
     }
 
     def complete(flowProcess: FlowProcess[_], call: AggregatorCall[X]): Unit = {
-      emit(flowProcess, call)
-    }
-
-    def emit(flowProcess: FlowProcess[_], call: AggregatorCall[X]): Unit = {
       call.getOutputCollector.add(set(call.getContext))
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
@@ -111,7 +111,7 @@ trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializ
     def log2(x: Double) = scala.math.log(x) / scala.math.log(2.0)
     val bits = 2 * scala.math.ceil(log2(104) - log2(errPercent)).toInt
     implicit val hmm = new HyperLogLogMonoid(bits)
-    mapPlusMap(f) { (t: T) => hmm(t) } (fn)
+    mapPlusMap(f) { (t: T) => hmm.create(t) } (fn)
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/filecache/DistributedCacheFile.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/filecache/DistributedCacheFile.scala
@@ -5,8 +5,9 @@ import com.twitter.scalding._
 import java.io.File
 import java.net.URI
 import java.nio.ByteBuffer
+
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapreduce.filecache.{ DistributedCache => HDistributedCache }
+import org.apache.hadoop.mapreduce.filecache.{DistributedCache => HDistributedCache}
 import org.apache.hadoop.fs.Path
 
 object URIHasher {
@@ -105,16 +106,16 @@ final case class UncachedFile private[scalding] (source: Either[String, URI]) {
   }
 
   private[this] def addHdfs(conf: Configuration): CachedFile = {
-    HDistributedCache.createSymlink(conf)
-
     def makeQualifiedStr(path: String, conf: Configuration): URI =
       makeQualified(new Path(path), conf)
 
     def makeQualifiedURI(uri: URI, conf: Configuration): URI =
       makeQualified(new Path(uri.toString), conf) // uri.toString because hadoop 0.20.2 doesn't take a URI
 
-    def makeQualified(p: Path, conf: Configuration): URI =
-      p.makeQualified(p.getFileSystem(conf)).toUri // make sure we have fully-qualified URI
+    def makeQualified(p: Path, conf: Configuration): URI = {
+      val fileSystem = p.getFileSystem(conf)
+      p.makeQualified(fileSystem.getUri, fileSystem.getWorkingDirectory).toUri
+    }
 
     val sourceUri =
       source match {


### PR DESCRIPTION
- REFACTOR: Fixed some compilation warnings
- REFACTOR: revert the changes to TemplateSource
- REFACTOR: revert the changes to CaseClassBasedSetterImpl and CaseClassFieldSetter for compatibility to 2.10
- REFACTOR: inline emit; avoid repeated calls to getFileSystem
- REFACTOR: remove the FileSystem annotation and related import
